### PR TITLE
Export HAWebsocketDurableObject from worker entrypoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -480,5 +480,5 @@ export default {
     ctx.waitUntil(env.MEMORY_KV.put(`daily-report:${report.generatedAt}`, JSON.stringify(report), { expirationTtl: 60 * 60 * 24 * 7 }));
   },
 };
-
+// Export the Durable Object class for Wrangler to bind.
 export { HAWebsocketDurableObject } from "./durable/haWebsocket";

--- a/src/index.ts
+++ b/src/index.ts
@@ -480,3 +480,5 @@ export default {
     ctx.waitUntil(env.MEMORY_KV.put(`daily-report:${report.generatedAt}`, JSON.stringify(report), { expirationTtl: 60 * 60 * 24 * 7 }));
   },
 };
+
+export { HAWebsocketDurableObject } from "./durable/haWebsocket";


### PR DESCRIPTION
## Summary
- re-export the HAWebsocketDurableObject class from the worker entrypoint so Wrangler can find it during deployment

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d99e19d7e8832eaeee9fefbb7167bc